### PR TITLE
Fix typo in ARC error message

### DIFF
--- a/GitUpKit/Core/GCCommitDatabase.m
+++ b/GitUpKit/Core/GCCommitDatabase.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import <sqlite3.h>

--- a/GitUpKit/Core/GCHistory.m
+++ b/GitUpKit/Core/GCHistory.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import <objc/runtime.h>

--- a/GitUpKit/Core/GCRepository+Reflog.m
+++ b/GitUpKit/Core/GCRepository+Reflog.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GCPrivate.h"

--- a/GitUpKit/Core/GCSnapshot.m
+++ b/GitUpKit/Core/GCSnapshot.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GCPrivate.h"

--- a/GitUpKit/Interface/GIBranch.m
+++ b/GitUpKit/Interface/GIBranch.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GIPrivate.h"

--- a/GitUpKit/Interface/GIGraph.m
+++ b/GitUpKit/Interface/GIGraph.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GIPrivate.h"

--- a/GitUpKit/Interface/GIGraphView.m
+++ b/GitUpKit/Interface/GIGraphView.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import <objc/runtime.h>

--- a/GitUpKit/Interface/GILayer.m
+++ b/GitUpKit/Interface/GILayer.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GIPrivate.h"

--- a/GitUpKit/Interface/GILine.m
+++ b/GitUpKit/Interface/GILine.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GIPrivate.h"

--- a/GitUpKit/Interface/GINode.m
+++ b/GitUpKit/Interface/GINode.m
@@ -14,7 +14,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if __has_feature(objc_arc)
-#error This file requires MRC
+#error This file requires ARC
 #endif
 
 #import "GIPrivate.h"


### PR DESCRIPTION
Was browsing the code and noticed this small typo. No functional changes.

P.S. Thank you so much for open sourcing this project. :smile_cat: